### PR TITLE
Make PyBlock compatible with Foreman 2.0

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -345,10 +345,8 @@ if not script.active_mods['pylandblock'] then
     end)
 
     script.on_configuration_changed(function()
-        if pcall(game.players[1].name == 'kingarthur') then
+        if not game.get_player('kingarthur') == nil then
             game.print('i see you')
-        else
-            -- game is running without players
         end
     end)
 

--- a/control.lua
+++ b/control.lua
@@ -344,12 +344,12 @@ if not script.active_mods['pylandblock'] then
         end
     end)
 
-script.on_configuration_changed(function()
-
-if game.players[1].name == 'kingarthur' then
-	game.print('i see you')
-end
-
-end)
+    script.on_configuration_changed(function()
+        if pcall(game.players[1].name == 'kingarthur') then
+            game.print('i see you')
+        else
+            -- game is running without players
+        end
+    end)
 
 end


### PR DESCRIPTION
I wanted to use Foreman 2.0 (Factorio Planner but outside the Factorio game) to experiment with a different Factorio Planner, but got a issue when trying the Foreman 2.0 tool. What Foreman 2.0 does is running the game in the background, so it can load all the entities in the Foreman 2.0 tool (I think).

This means that the `control.lua` script gets executed by the Foreman 2.0 tool, without any players.

When running the tool with import I got this issue:

```
   0.000 Error Util.cpp:83: The mod PyBlock (0.2.2) caused a non-recoverable error.
Please report this error to the mod author.

Error while running event PyBlock::on_configuration_changed
__PyBlock__/control.lua:348: attempt to index field '?' (a nil value)
stack traceback:
	__PyBlock__/control.lua:348: in function <__PyBlock__/control.lua:347>

------------- Error -------------
The mod PyBlock (0.2.2) caused a non-recoverable error.
Please report this error to the mod author.

Error while running event PyBlock::on_configuration_changed
__PyBlock__/control.lua:348: attempt to index field '?' (a nil value)
stack traceback:
	__PyBlock__/control.lua:348: in function <__PyBlock__/control.lua:347>
---------------------------------
```

It had something to do with this personal greeting method:

```lua
script.on_configuration_changed(function()

if game.players[1].name == 'kingarthur' then
	game.print('i see you')
end

end)
```

To fix this issue the only thing needed to change is the implementation if the game has a player named 'kingarthur':

```lua
script.on_configuration_changed(function()
    if not game.get_player('kingarthur') == nil then
        game.print('i see you')
    end
end)
```

When running Foreman2.0 The issue is resolved with the second implementation. The only thing I can't test is if the personal greeting message still works, since my name is not kingarthur.