### PR TITLE
Fix hot coals handsorting

### DIFF
--- a/prototypes/recipes/recipes-zerostart.lua
+++ b/prototypes/recipes/recipes-zerostart.lua
@@ -104,7 +104,7 @@ RECIPE{
 
 -- sort through coals
 RECIPE{
-  name = "handsort-coals",
+  name = "handsort-hot-coals",
   enabled = true,
   energy_required = 1,
   category = "handcrafting",


### PR DESCRIPTION
There is a name in recipe that doesn't match one in the locale. Recipe doesn't show ingame.