### PR TITLE
Fix world generation preset string formatting

### DIFF
--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -124,7 +124,7 @@ pyblock-archipeligo=PyBlock Archipeligo
 pyblock-landblock=PyLandBlock
 
 [map-gen-preset-description]
-pyblock-recommended=These are the recommend settings for playing PyBlock. Resources, trees, rocks, cliffs, and most land are disabled.\nIf you want to play with more land, increase the island size or switch to the [/color]Landblock[color=red] preset from the dropdown above.
+pyblock-recommended=These are the recommend settings for playing PyBlock. Resources, trees, rocks, cliffs, and most land are disabled.\nIf you want to play with more land, increase the island size or switch to the [color=red]Landblock[/color] preset from the dropdown above.
 pyblock-classic=This is classic PyBlock. Resources, trees, rocks, cliffs, and most land are disabled. You start on a single tile of landfill and must build the world as you go.\nIf you want to play with more land, switch to PyBlock Recommended preset from the dropdown above.
 pyblock-archipeligo=This is a variation of pyblock where small islands generate, occasionally containing useful resources, but must of your production comes from normal PyBlock methods.
 pyblock-landblock=This is a variation of pyblock where normal terrain generates, but no resources. Build up using normal PyBlock technology with none of the space constraints! 


### PR DESCRIPTION
Fixes a formatting issue with the PyBlock Reccomended generation present description string
Before:
<img width="1062" height="210" alt="image" src="https://github.com/user-attachments/assets/4fbd8ab8-8f23-402b-9825-ccb29f2ec1b3" />
After:
<img width="645" height="123" alt="image" src="https://github.com/user-attachments/assets/6abf0151-1990-4e52-bf0f-7f29d1623040" />
