### PR TITLE
fixed shunt inserter infinite consumption

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,14 @@
 ---------------------------------------------------------------------------------------------------
+Version: 3.3.1
+Date: ????
+  Changes:
+    - Fixed that shunt inserters would attempt to burn steam. Resolves https://github.com/pyanodon/pybugreports/issues/1550
+---------------------------------------------------------------------------------------------------
 Version: 3.3.0
 Date: 2026-07-30
   Changes:
     - Updated for 2.1
-    - Updated shunt inserter graphics. Thank you Talander!
+    - Updated shunt inserter graphics. Thank you Talandar!
     - Removed steam engine minimum steam temperature as a stopgap fix until wube fixed fluid temp 'mixing'
   Bugfixes:
     - Fixed that alt names were concatenated instead of chosen. Resolves https://github.com/pyanodon/pybugreports/issues/1497

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "PyBlock",
-	"version": "3.3.0",
+	"version": "3.3.1",
 	"factorio_version": "2.1",
 	"title": "PyBlock",
 	"author": "KingArthur, protocol_1903",

--- a/prototypes/buildings/shunt-inserter.lua
+++ b/prototypes/buildings/shunt-inserter.lua
@@ -104,7 +104,7 @@ ENTITY {
     damaged_trigger_effect = hit_effects.entity(),
     energy_source = {
       type = "fluid",
-      burns_fluid = true,
+      burns_fluid = false,
       scale_fluid_usage = true,
       fluid_box = {
         volume = 20,

--- a/prototypes/buildings/shunt-inserter.lua
+++ b/prototypes/buildings/shunt-inserter.lua
@@ -104,7 +104,6 @@ ENTITY {
     damaged_trigger_effect = hit_effects.entity(),
     energy_source = {
       type = "fluid",
-      burns_fluid = false,
       scale_fluid_usage = true,
       fluid_box = {
         volume = 20,


### PR DESCRIPTION
There is a bug in 2.1 where shunt inserters would consume an infinite amount of steam. This was caused by burns_fluid being set to true making shunt inserters use steam's fuel_value instead of its heat_capacity. Since steam is not a fuel it has a fuel_value of 0 causing shunt inserters to consume it infinitely and get no energy. 

Resolves https://github.com/pyanodon/pybugreports/issues/1550